### PR TITLE
Support prebuilt-sources and add some additional config options

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -1,0 +1,26 @@
+name: Regression Tests
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.4, 3.5, 3.6, 3.7, 3.8]
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 tox graphviz
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          tox -e lint
+      - name: Test
+        run: |
+          tox -e test

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.4, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     
     steps:
       - uses: actions/checkout@v2

--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -26,6 +26,13 @@ Setup Development Environment
       git config flake8.strict true
 
 
+#. Install Other Requirements
+
+   ::
+
+      # For inheritance diagram
+      sudo apt-get install graphviz
+
 Building Documentation
 ======================
 
@@ -52,4 +59,4 @@ Running Test Suite
 
 ::
 
-   tox -e py27,py34
+   tox -e test

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -101,6 +101,18 @@ Usage
             |-- mymodule.rst
             |-- mymodule.submodule.rst
             `-- mymodule.another.rst
+   :orphan: ``bool``
+    Inserts the `orphan <https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html#orphan>`_ 
+    directive to all generated contents from this module.
+   :module-members: ``list ['str']``
+    Include additional members to document when generating for a ``module``.
+    Options are ``undoc-members``, ``special-members``, and ``private-members``
+   :class-members: ``list ['str']``
+    Include additional members to document. These are inserted as
+    `directives <https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directives>`_
+    into the resulting ``.rst`` for ``classes``.
+   :exclude-members: ``list ['str']``
+    Enumerated members to exclude from resulting ``.rst``.
 
    For example, a custom configuration could be:
 
@@ -112,6 +124,27 @@ Usage
             'output': 'auto'
          }
       }
+
+#. Configure Auxillary AutoAPI Settings
+
+   Other options available in your Sphinx's ``conf.py``:
+
+   .. code-block:: python
+
+      # Output directory to place generated contents.
+      # Can be absolute or relative to your Sphinx's ``conf.py``.
+      autoapi_output_dir = '...'
+
+   AutoAPI also supports a listener to post-process an ``APINode``.
+   Each node will be given to this method in turn:
+
+   .. code-block:: python
+
+      def setup(app):
+         def postprocess_node(app, node):
+            ...
+      
+         app.connect('autoapi-process-node', postprocess_node)
 
 #. Reference your documentation in your Sphinx project:
 

--- a/examples/apinode.py
+++ b/examples/apinode.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     for node, leaves in m.walk():
         print(
             '{} node has leaves: {}'.format(
-                node.name, ', '.join([l.name for l in leaves])
+                node.name, ', '.join([leaf.name for leaf in leaves])
             )
         )
 

--- a/lib/autoapi/apinode.py
+++ b/lib/autoapi/apinode.py
@@ -182,7 +182,7 @@ class APINode(object):
                 for subname in getattr(self.module, public_key):
                     if not hasattr(self.module, subname):
                         log.warning(
-                            'Module {} doesn\'t have a element {}'.format(
+                            "Module {} doesn't have a element {}".format(
                                 self.name,
                                 subname
                             )

--- a/lib/autoapi/apinode.py
+++ b/lib/autoapi/apinode.py
@@ -181,13 +181,22 @@ class APINode(object):
 
                 for subname in getattr(self.module, public_key):
                     if not hasattr(self.module, subname):
-                        log.warning('Module {} doesn\'t have a element {}'.format(self.name, subname))
+                        log.warning(
+                            'Module {} doesn\'t have a element {}'.format(
+                                self.name,
+                                subname
+                            )
+                        )
                         continue
                     elif ismodule(getattr(self.module, subname)):
                         submod = getattr(self.module, subname)
                         try:
                             mod_name = f'{self.name}.{submod.__name__}'
-                            subnode = APINode(mod_name, self.directory, prebuilt=True)
+                            subnode = APINode(
+                                mod_name,
+                                self.directory,
+                                prebuilt=True
+                            )
                             self.subnodes.append(subnode)
                         except Exception:
                             log.error('Failed to import {}'.format(subname))

--- a/lib/autoapi/sphinx.py
+++ b/lib/autoapi/sphinx.py
@@ -130,6 +130,13 @@ def builder_inited(app):
             'exclude-members': []
         }
 
+        # Unless the user explicitly passed in the option, base the
+        # inheritance-diagram-available option on whether or not the
+        # appropriate extension is available.
+        if 'inheritance-diagram-available' not in options:
+            options['inheritance-diagram-available'] = \
+                'sphinx.ext.inheritance_diagram' in app.extensions
+
         if overrides:
             options.update(overrides)
 
@@ -145,7 +152,8 @@ def builder_inited(app):
                 'app': app,
                 'module-members': options['module-members'],
                 'class-members': options['class-members'],
-                'exclude-members': options['exclude-members']
+                'exclude-members': options['exclude-members'],
+                'inheritance_diagram_available': options['inheritance-diagram-available'],
             }
         )
 

--- a/lib/autoapi/sphinx.py
+++ b/lib/autoapi/sphinx.py
@@ -148,7 +148,7 @@ def builder_inited(app):
         # Build API tree
         tree = APINode(
             module,
-            context = {
+            context={
                 'app': app,
                 'module-members': options['module-members'],
                 'class-members': options['class-members'],
@@ -202,7 +202,8 @@ def builder_inited(app):
                         node=node,
                         subnodes=subnodes,
                         orphan=options['orphan'],
-                        inheritance_diagram_available=options['inheritance-diagram-available'],
+                        inheritance_diagram_available=options[
+                            'inheritance-diagram-available'],
                     )
                 )
 

--- a/lib/autoapi/sphinx.py
+++ b/lib/autoapi/sphinx.py
@@ -124,8 +124,12 @@ def builder_inited(app):
             'override': True,
             'template': 'module',
             'output': module,
-            'orphan': False
+            'orphan': False,
+            'module-members': [],
+            'class-members': [],
+            'exclude-members': []
         }
+
         if overrides:
             options.update(overrides)
 
@@ -135,7 +139,15 @@ def builder_inited(app):
         )
 
         # Build API tree
-        tree = APINode(module)
+        tree = APINode(
+            module,
+            context = {
+                'app': app,
+                'module-members': options['module-members'],
+                'class-members': options['class-members'],
+                'exclude-members': options['exclude-members']
+            }
+        )
 
         # Gather nodes to document
         if options['prune']:
@@ -182,7 +194,7 @@ def builder_inited(app):
                     template.render(
                         node=node,
                         subnodes=subnodes,
-                        orphan=options['orphan']
+                        orphan=options['orphan'],
                     )
                 )
 
@@ -197,6 +209,7 @@ def setup(app):
     app.setup_extension('sphinx.ext.autodoc')
     app.add_config_value('autoapi_modules', {}, True)
     app.add_config_value('autoapi_output_dir', None, True)
+    app.add_event(APINode.autoapi_process_node_func_name)
     app.connect(str('builder-inited'), builder_inited)
     return {'version': __version__}
 

--- a/lib/autoapi/sphinx.py
+++ b/lib/autoapi/sphinx.py
@@ -151,7 +151,10 @@ def builder_inited(app):
 
         # Define output directory
         if app.config.autoapi_output_dir:
-            out_dir = join(Path(app.config.autoapi_output_dir), options['output'])
+            out_dir = join(
+                Path(app.config.autoapi_output_dir),
+                options['output']
+            )
         else:
             out_dir = join(app.env.srcdir, options['output'])
         ensuredir(out_dir)

--- a/lib/autoapi/sphinx.py
+++ b/lib/autoapi/sphinx.py
@@ -153,7 +153,6 @@ def builder_inited(app):
                 'module-members': options['module-members'],
                 'class-members': options['class-members'],
                 'exclude-members': options['exclude-members'],
-                'inheritance_diagram_available': options['inheritance-diagram-available'],
             }
         )
 
@@ -203,6 +202,7 @@ def builder_inited(app):
                         node=node,
                         subnodes=subnodes,
                         orphan=options['orphan'],
+                        inheritance_diagram_available=options['inheritance-diagram-available'],
                     )
                 )
 

--- a/lib/autoapi/sphinx.py
+++ b/lib/autoapi/sphinx.py
@@ -19,6 +19,7 @@
 Glue for Sphinx API.
 """
 
+from pathlib import Path
 from inspect import getdoc
 from functools import wraps
 from traceback import format_exc
@@ -122,7 +123,8 @@ def builder_inited(app):
             'prune': False,
             'override': True,
             'template': 'module',
-            'output': module
+            'output': module,
+            'orphan': False
         }
         if overrides:
             options.update(overrides)
@@ -148,7 +150,10 @@ def builder_inited(app):
             continue
 
         # Define output directory
-        out_dir = join(app.env.srcdir, options['output'])
+        if app.config.autoapi_output_dir:
+            out_dir = join(Path(app.config.autoapi_output_dir), options['output'])
+        else:
+            out_dir = join(app.env.srcdir, options['output'])
         ensuredir(out_dir)
 
         # Iterate nodes and render them
@@ -173,7 +178,8 @@ def builder_inited(app):
                 fd.write(
                     template.render(
                         node=node,
-                        subnodes=subnodes
+                        subnodes=subnodes,
+                        orphan=options['orphan']
                     )
                 )
 
@@ -187,6 +193,7 @@ def setup(app):
     # autodoc is required
     app.setup_extension('sphinx.ext.autodoc')
     app.add_config_value('autoapi_modules', {}, True)
+    app.add_config_value('autoapi_output_dir', None, True)
     app.connect(str('builder-inited'), builder_inited)
     return {'version': __version__}
 

--- a/lib/autoapi/templates/autoapi/module.rst
+++ b/lib/autoapi/templates/autoapi/module.rst
@@ -1,3 +1,8 @@
+{% if orphan -%}
+:orphan:
+
+{% endif -%}
+
 =={{ '=' * node.name|length }}==
 ``{{ node.name }}``
 =={{ '=' * node.name|length }}==
@@ -57,11 +62,12 @@ Classes
 {% for item in node.classes %}
 .. autoclass:: {{ item }}
    :members:
-
+{% if not node.prebuilt %}
    .. rubric:: Inheritance
    .. inheritance-diagram:: {{ item }}
       :parts: 1
-{##}
+{%- endif -%}
+
 {%- endfor -%}
 {%- endif -%}
 {%- endblock -%}
@@ -102,11 +108,12 @@ Variables
 {% for item, obj in node.variables.items() %}
 .. autodata:: {{ item }}
    :annotation:
-
+{% if not node.prebuilt %}
    .. code-block:: text
 
       {{ obj|pprint|indent(6) }}
-{##}
+{%- endif -%}
+
 {%- endfor -%}
 {%- endif -%}
 {%- endblock -%}

--- a/lib/autoapi/templates/autoapi/module.rst
+++ b/lib/autoapi/templates/autoapi/module.rst
@@ -71,7 +71,7 @@ Classes
 {%- for d in obj[1]['directives'] %}
    :{{ d }}:
 {%- endfor %}
-{% if inheritance_diagram_available %}
+{% if inheritance_diagram_available -%}
 {% if not node.prebuilt %}
    .. rubric:: Inheritance
    .. inheritance-diagram:: {{ item }}

--- a/lib/autoapi/templates/autoapi/module.rst
+++ b/lib/autoapi/templates/autoapi/module.rst
@@ -98,9 +98,11 @@ Exceptions
 {% for item in node.exceptions %}
 .. autoexception:: {{ item }}
 
+{% if inheritance_diagram_available -%}
    .. rubric:: Inheritance
    .. inheritance-diagram:: {{ item }}
       :parts: 1
+{%- endif -%}
 {##}
 {%- endfor -%}
 {%- endif -%}

--- a/lib/autoapi/templates/autoapi/module.rst
+++ b/lib/autoapi/templates/autoapi/module.rst
@@ -71,10 +71,12 @@ Classes
 {%- for d in obj[1]['directives'] %}
    :{{ d }}:
 {%- endfor %}
+{% if inheritance_diagram_available %}
 {% if not node.prebuilt %}
    .. rubric:: Inheritance
    .. inheritance-diagram:: {{ item }}
       :parts: 1
+{%- endif -%}
 {%- endif -%}
 
 {%- endfor -%}

--- a/lib/autoapi/templates/autoapi/module.rst
+++ b/lib/autoapi/templates/autoapi/module.rst
@@ -1,3 +1,10 @@
+{% if node.opts['rst-pre-title']|length > 0 -%}
+{% for block in node.opts['rst-pre-title'] -%}
+{{ block }}
+
+{%- endfor %}
+{% endif -%}
+
 {% if orphan -%}
 :orphan:
 
@@ -36,7 +43,7 @@ Functions
 
 {% for item, obj in node.functions.items() -%}
 - :py:func:`{{ item }}`:
-  {{ obj|summary }}
+  {{ obj[0]|summary }}
 
 {% endfor -%}
 
@@ -55,13 +62,15 @@ Classes
 
 {% for item, obj in node.classes.items() -%}
 - :py:class:`{{ item }}`:
-  {{ obj|summary }}
+  {{ obj[0]|summary }}
 
 {% endfor -%}
 
-{% for item in node.classes %}
+{% for item, obj in node.classes.items() %}
 .. autoclass:: {{ item }}
-   :members:
+{%- for d in obj[1]['directives'] %}
+   :{{ d }}:
+{%- endfor %}
 {% if not node.prebuilt %}
    .. rubric:: Inheritance
    .. inheritance-diagram:: {{ item }}
@@ -80,7 +89,7 @@ Exceptions
 
 {% for item, obj in node.exceptions.items() -%}
 - :py:exc:`{{ item }}`:
-  {{ obj|summary }}
+  {{ obj[0]|summary }}
 
 {% endfor -%}
 
@@ -107,11 +116,15 @@ Variables
 
 {% for item, obj in node.variables.items() %}
 .. autodata:: {{ item }}
-   :annotation:
+{%- for d in obj[1]['directives'] %}
+   :{{ d }}:
+{%- endfor %}
 {% if not node.prebuilt %}
+{%- if item is upper %}
    .. code-block:: text
 
-      {{ obj|pprint|indent(6) }}
+      {{ obj[0]|pprint|indent(6) }}
+{%- endif -%}
 {%- endif -%}
 
 {%- endfor -%}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = test, doc
+envlist = test, doc, lint
 
 
 [testenv]
@@ -13,7 +13,6 @@ deps =
     -rtest/requirements.txt
 commands =
     {envpython} -c "import autoapi; print(autoapi.__file__)"
-    flake8 {toxinidir}
     py.test {posargs} \
         --junitxml=tests.xml \
         --cov=autoapi \
@@ -32,6 +31,11 @@ commands =
     sphinx-build -W -b html -d doctrees {toxinidir}/doc/ html
     {envpython} -c "print('>> You may now run:\nwebdev {envtmpdir}/html/')"
 
+[testenv:lint]
+deps =
+    -rtest/requirements.txt
+commands =
+    flake8 {toxinidir}
 
 [flake8]
 exclude = .git,.tox,.cache,__pycache__,*.egg-info


### PR DESCRIPTION
Hello,

I started using this package for API generation but found it lacked a couple controls for my use case. The project I  use this for runs on a pre-built `.so/.pyd`, and have some changes to support this, but early versions of the `.so/.pyd` generated had spotty documentation support. `AutoAPI` was fantastic for getting me 90% of the way there and I added some options to help get me the remaining 10% without resorting to post-processing of the resulting reST. These updates should be applicable to the package at-large though and I'm hoping others will find it useful as well.

### Support for Prebuilt Libraries

I rolled a simple [is_prebuilt](https://github.com/coreyeng/autoapi/blob/dev4/lib/autoapi/apinode.py#L443-L453) method which just detects if the source is a `.so` or `.pyd` and, if so, updates the roots appropriately as well as breaking up the imported module into its submodules.

### Added Member Controls

The foremost problem I had was that my `.pyd` source was what it was - there wasn't much I could to about that. But, with a few updates here, I was able to expand/whittle down the generation to only those members which I needed, which was much preferred to post-processing the reST source.

I added some configuration-level options for `module-members`, `class-members`, and `exclude-members`. The first accepts a [list of enumerated values](https://github.com/coreyeng/autoapi/blob/dev4/lib/autoapi/apinode.py#L232-L243) which can be removed from `all members`.  However, `__api__` or `__all__` still have priority.

I added `class-members` to pass configuration options when auto-doc-ing classes. This was much less involved than dealing with  modules above and boils down to just inserting the given `directives` [in the right place](https://github.com/coreyeng/autoapi/blame/dev4/lib/autoapi/templates/autoapi/module.rst#L71-L73) to facilitate generation. However, this should will allow for future extension, if it comes up.

Lastly, [exclude-members](https://github.com/coreyeng/autoapi/blob/dev4/lib/autoapi/apinode.py#L265-L269) is used to exclude anything and will operate even when `__all__` or `__api__` is defined.

### Listeners

I added an [event](https://github.com/coreyeng/autoapi/blob/dev4/lib/autoapi/sphinx.py#L221) for Sphinx that also allows for any member-specific content to be added dynamically. This will yield the `APINode` and [any post-processing](https://github.com/coreyeng/autoapi/blob/dev4/lib/autoapi/apinode.py#L298-L299) can be done by the user prior to generating the `.rst`.

### Other Config

I added a few other config options as well:

*` orphan` - inserts the `orphan` directive for private modules which we want documented but not necessarily in the TOC (e.g. private libraries).
* `autoapi_output_dir` - Sets the output directory of the `.rst` content.
* `inheritance-diagram-available` - Override for using the `inheritance diagram`, even if its available at the `project level`.

### Doc/Developer Updates

I updated the documentation appropriately. I also made some minor updates to the `developers` section. You had python 2.7 and 3.4 listed, but it seems that [Python 2.7 support was removed over a year ago](https://github.com/carlos-jenkins/autoapi/commit/4d1c15c432af845f144c7e10b9ed58eee12082b7). Python 3.4 is EoL-ed, and the `flake8` command actually fails to run at all prior to 3.6.

I also split the linting and testing step up. I generally focusing on getting tests to pass first then go back through and adhere to coding styles.

### Github Actions

I added some CI via [Github Actions](https://github.com/coreyeng/autoapi/blob/dev4/.github/workflows/regression_test.yml). I set it up to run on Ubuntu for Python version 3.6, 3.7, and 3.8. Both linting and testing steps are added, even though they are split up.

FWIW, I did my development on 3.8 in Windows and Ubuntu via WSL.

Thanks!
